### PR TITLE
re-instated license for imagehash

### DIFF
--- a/python/imagehash.py
+++ b/python/imagehash.py
@@ -1,4 +1,3 @@
-
 from PIL import Image
 import numpy
 import scipy.fftpack
@@ -6,6 +5,19 @@ import scipy.fftpack
 """
 This file is a clone of the pip ImageHash library at https://github.com/JohannesBuchner/imagehash
 PyPI states that the ImageHash is for Python 2.7.  This clone of it is for Python 3.5.
+"""
+
+"""
+Copyright (c) 2013-2016, Johannes Buchner
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 """
 
 def _binary_array_to_hex(arr):


### PR DESCRIPTION
I am happy that you chose to use source code I wrote. That is what open source is all about. But please respect the BSD license, which only requests only two things - a copyright notice and warranty disclaimers. This commit re-instates these for your copy.
Alternatively, you can import the module imagehash (it is in pypi) through setup.py and through that always get the latest version.
Imagehash should work fine for python3 out of the box. If it does not, please file a bug.